### PR TITLE
[FIX] Removed recipes that are not present on createbb or create

### DIFF
--- a/src/main/resources/data/createbb/recipes/misc/smelt_copper_dust.json
+++ b/src/main/resources/data/createbb/recipes/misc/smelt_copper_dust.json
@@ -1,9 +1,0 @@
-{
-  "type": "minecraft:smelting",
-  "ingredient": {
-    "item": "createbb:copper_dust"
-  },
-  "result": "minecraft:copper_ingot",
-  "experience": 0.1,
-  "cookingtime": 200
-}

--- a/src/main/resources/data/createbb/recipes/misc/smelt_zinc_dust.json
+++ b/src/main/resources/data/createbb/recipes/misc/smelt_zinc_dust.json
@@ -1,9 +1,0 @@
-{
-  "type": "minecraft:smelting",
-  "ingredient": {
-    "item": "createbb:zinc_dust"
-  },
-  "result": "create:zinc_ingot",
-  "experience": 0.1,
-  "cookingtime": 200
-}


### PR DESCRIPTION
- Mods loaded:
CreateBB-1.20.1-3.2.1
Create-1.20.1-0.5.f
Forge-1.20.1-47.3.0
- Issue:
When you loaded the mod createbb it appear an error that 2 recipes could not be loaded because two items were missing. Removed the recipes because on createbb and create mods are not present those items and has no other mod dependencies.

Log output of the error:
[log.txt](https://github.com/user-attachments/files/16013102/log.txt)
